### PR TITLE
Corrected on.schedule syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Below is an example of using this action in conjunction with [Create Issue From 
 ```yml
 on:
   schedule:
-  - cron: 0 0 1 * *
+  - cron: '0 0 1 * *'
 name: Check markdown links
 jobs:
   linkChecker:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Below is an example of using this action in conjunction with [Create Issue From 
 
 ```yml
 on:
-  schedules:
+  schedule:
   - cron: 0 0 1 * *
 name: Check markdown links
 jobs:


### PR DESCRIPTION
Hello,

I used example code in README.md to my project but error was happen.

https://github.com/user340/www/commit/694e8f57a2f79e624a57f5e1ca1c66c83c1908d6/checks?check_suite_id=377203533

This is syntax problem. So I fixed it.