### PR TITLE
Propagate liche exit code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,4 +25,4 @@ fi
 cat /tmp/link-checker/out
 
 # Propagate liche exit code
-exit $exit_code
+echo ::set-output name=exit_code::$exit_code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,5 +24,5 @@ fi
 # Output to console
 cat /tmp/link-checker/out
 
-# Propagate liche exit code
+# Pass Liche exit code to next step
 echo ::set-output name=exit_code::$exit_code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,10 @@ mkdir -p /tmp/link-checker
 
 # Execute Liche
 liche $* >/tmp/link-checker/out 2>&1
+exit_code=$?
 
 # If link errors were found output a report to the designated directory
-if [ $? -eq 1 ]; then
+if [ $exit_code -eq 1 ]; then
     mkdir -p $LINKCHECKER_OUTPUT_DIR
     echo -e '### Link Checker\nErrors were reported while checking the connectivity of links.\n```' \
         >$LINKCHECKER_OUTPUT_DIR/$LINKCHECKER_OUTPUT_FILENAME
@@ -22,3 +23,6 @@ fi
 
 # Output to console
 cat /tmp/link-checker/out
+
+# Propagate liche exit code
+exit $exit_code


### PR DESCRIPTION
The current link-checker action returns 0 regardless of errors found since it returns the return code of `cat`.
To mark failure on the pull request page, the action should output "whether errors are found or not".